### PR TITLE
feat: stitching options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,50 @@
-# mercurius-postgraphile
+# Mercurius PostGraphile
 
-Fastify plugin for integrating postgraphile schemas with mercurius
+> A [Fastify](https://www.fastify.io/docs/latest/) plugin for integrating [PostGraphile](https://www.graphile.org/postgraphile/) schemas with [Mercurius](https://mercurius.dev/)
 
-## Getting Started
+## Contents
 
+- [Usage](#usage)
+- [API](#api)
+- [Example](#example)
+
+## Usage
+
+```sh
+npm i @autotelic/mercurius-postgraphile
 ```
+
+```js
+const mercuriusPostGraphile = require('@autotelic/mercurius-postgraphile')
+const { Pool } = require('pg')
+const connectionString = process.env.DATABASE_URL
+const pgPool = new Pool({ connectionString })
+
+module.exports = async function (fastify, options) {
+  fastify.register(mercuriusPostGraphile, {
+    connectionString,
+    pgPool
+  })
+}
+```
+
+## API
+
+### `Options`
+
+| Name | Status | Type | Default | Description |
+| ------- | :---: | :---: | :---: | --- |
+| `connectionString` | **Required** | String | - | A postgreSQL database connection string, i.e. `postgres://postgres:password@0.0.0.0:5432/postgres?sslmode=disable`. |
+| `pgPool` | **Required** | Object | - | A client or pool instance that will be passed to the [pg](https://node-postgres.com/) library and used to connect to a PostgreSQL backend. |
+| `instanceName` | Optional | String | `public` | A string which specifies the PostgreSQL schema that PostGraphile will use to create a GraphQL schema. |
+| `localStitchOpts` | Optional | Object | `{}` | An object containing local subschema config options. |
+| `postgraphileStitchOpts` | Optional | Object | `{}` | An object containing PostGraphile subschema config options. `stitchOpts` for both the local and PostGraphile schemas implement the `SubschemaConfig` interface. [Documention can be found here](https://www.graphql-tools.com/docs/stitch-combining-schemas#subschema-configs) |
+| `postgraphileContextOpts` | Optional | Object/Function | `{}` | An object or callback function containing `withPostGraphileContext` options, outlined [here](https://www.graphile.org/postgraphile/usage-schema/#api-withpostgraphilecontextoptions-callback) |
+| `postgraphileSchemaOpts` | Optional | Object | `{}` | An object containing `createPostGraphileSchema` options, outlined [here](https://www.graphile.org/postgraphile/usage-schema/#api-createpostgraphileschemapgconfig-schemaname-options) |
+
+## Example
+
+```sh
 npm i
 docker-compose up -d
 npm run test

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "homepage": "https://github.com/autotelic/mercurius-postgraphile#readme",
   "dependencies": {
-    "@graphql-tools/delegate": "^7.1.5",
     "@graphql-tools/stitch": "^7.5.3",
     "fastify-plugin": "^3.0.0",
     "postgraphile": "^4.12.3"


### PR DESCRIPTION
### Summary
Co-authored with @HW13. This PR adds `localStitchOpts`, `postgraphileContextOpts`, `postgraphileSchemaOpts`, `postgraphileStitchOpts` to the plugin's configuration options.

### Test Plan
- checkout and pull `feat/stitch-opts`, install dependencies with `npm`
- start a postgres container:
  ```sh
  docker-compose up -d
  ```
- run tests:
  ```sh
  npm run test
  ```
- checkout the docs for improvements to the options table and areas we may want to enhance for clarity