### PR TITLE
feat: add example service

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 - [Usage](#usage)
 - [API](#api)
-- [Example](#example)
+- [Run the Example](#run-the-example)
+- [Resources](#resources)
 
 ## Usage
 
@@ -38,14 +39,52 @@ module.exports = async function (fastify, options) {
 | `pgPool` | **Required** | Object | - | A client or pool instance that will be passed to the [pg](https://node-postgres.com/) library and used to connect to a PostgreSQL backend. |
 | `instanceName` | Optional | String | `public` | A string which specifies the PostgreSQL schema that PostGraphile will use to create a GraphQL schema. |
 | `localStitchOpts` | Optional | Object | `{}` | An object containing local subschema config options. |
-| `postgraphileStitchOpts` | Optional | Object | `{}` | An object containing PostGraphile subschema config options. `stitchOpts` for both the local and PostGraphile schemas implement the `SubschemaConfig` interface. [Documention can be found here](https://www.graphql-tools.com/docs/stitch-combining-schemas#subschema-configs) |
-| `postgraphileContextOpts` | Optional | Object/Function | `{}` | An object or callback function containing `withPostGraphileContext` options, outlined [here](https://www.graphile.org/postgraphile/usage-schema/#api-withpostgraphilecontextoptions-callback) |
-| `postgraphileSchemaOpts` | Optional | Object | `{}` | An object containing `createPostGraphileSchema` options, outlined [here](https://www.graphile.org/postgraphile/usage-schema/#api-createpostgraphileschemapgconfig-schemaname-options) |
+| `postGraphileStitchOpts` | Optional | Object | `{}` | An object containing PostGraphile subschema config options. `stitchOpts` for both the local and PostGraphile schemas implement the `SubschemaConfig` interface. [Documention can be found here](https://www.graphql-tools.com/docs/stitch-combining-schemas#subschema-configs) |
+| `postGraphileContextOpts` | Optional | Object/Function | `{}` | An object or callback function containing `withPostGraphileContext` options, outlined [here](https://www.graphile.org/postgraphile/usage-schema/#api-withpostgraphilecontextoptions-callback) |
+| `postGraphileSchemaOpts` | Optional | Object | `{}` | An object containing `createPostGraphileSchema` options, outlined [here](https://www.graphile.org/postgraphile/usage-schema/#api-createpostgraphileschemapgconfig-schemaname-options) |
 
-## Example
+## Run the Example
+
+#### Install Dependencies and Run a Local Postgres Container
 
 ```sh
 npm i
 docker-compose up -d
-npm run test
 ```
+
+#### Run the server
+
+```sh
+npm run example
+```
+
+#### Make Requests to the Server
+
+```sh
+http :3000/graphql
+http POST :3000/graphql
+```
+
+#### Explore Graphiql
+
+[http://localhost:3000/graphiql](http://localhost:3000/graphiql)
+
+The `user` query from PostGraphile and the `localUser` query from Mercurius are used to merge the `User` type. Check out the [example](https://github.com/autotelic/mercurius-postgraphile/tree/main/example/index.js) to explore the stitch options implemented in merging the local and PostGraphile schemas.
+
+```gql
+query {
+  user(id: 1) {
+    username
+    verified
+  }
+  localUser(id: 1) {
+    username
+    verified
+  }
+}
+```
+
+## Resources
+
+- [Schema-Only PostGraphile](https://www.graphile.org/postgraphile/usage-schema/)
+- [Schema Stitching](https://www.graphql-tools.com/docs/stitch-combining-schemas)

--- a/example/index.js
+++ b/example/index.js
@@ -1,0 +1,71 @@
+const mercuriusPostGraphile = require('..')
+const { Pool } = require('pg')
+const DEFAULT_INFLECTOR = require('@graphile-contrib/pg-simplify-inflector')
+
+const schema = `
+  type Query {
+    localUser(id: Int!): User
+  }
+
+  type User {
+    id: Int!
+    verified: Boolean
+  }
+`
+
+const resolvers = {
+  Query: {
+    async localUser (obj, params, context) {
+      return { id: params.id }
+    }
+  },
+  User: {
+    async verified () {
+      return true
+    }
+  }
+}
+
+const connectionString = 'postgres://postgres:postgres@0.0.0.0:5432/postgres?sslmode=disable'
+
+const pgPool = new Pool({ connectionString })
+
+const postGraphileSchemaOpts = {
+  appendPlugins: [DEFAULT_INFLECTOR]
+}
+
+const postGraphileStitchOpts = {
+  merge: {
+    User: {
+      fieldName: 'user',
+      selectionSet: '{ id }',
+      args: originalObject => ({ id: originalObject.id })
+    }
+  }
+}
+
+const localStitchOpts = {
+  merge: {
+    User: {
+      fieldName: 'localUser',
+      selectionSet: '{ id }',
+      args: originalObject => ({ id: originalObject.id })
+    }
+  }
+}
+
+module.exports = async function (fastify, options) {
+  fastify.register(require('mercurius'), {
+    resolvers,
+    schema,
+    graphiql: 'graphiql'
+  })
+
+  fastify.register(mercuriusPostGraphile, {
+    connectionString,
+    pgPool,
+    postGraphileSchemaOpts,
+    postGraphileStitchOpts,
+    localStitchOpts
+  })
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "tap --100 -j1 -R classic",
-    "example": "echo no example provided",
+    "example": "fastify start -w -l info -P ./example/index.js",
     "lint": "standard",
     "fix": "npm run lint -- --fix",
     "validate": "npm run lint && npm run test"
@@ -36,13 +36,14 @@
     "postgraphile": "^4.12.3"
   },
   "devDependencies": {
-    "tap": "^15.0.6",
+    "@graphile-contrib/pg-simplify-inflector": "^6.1.0",
     "fastify": "^3.0.0",
     "fastify-cli": "^2.5.1",
+    "lint-staged": "^10.2.11",
     "mercurius": "^7.9.1",
     "pg": "^8.6.0",
     "standard": "^16.0.3",
-    "lint-staged": "^10.2.11"
+    "tap": "^15.0.6"
   },
   "lint-staged": {
     "*.{js,jsx}": [


### PR DESCRIPTION
### Summary
To demonstrate `mercurius-postgraphile`, this PR adds an example service with an interactive playground to explore the graph.

### Test Plan
- checkout and pull `feat/example`, install dependencies with `npm`
- start a postgres container and run the example:

```sh
docker-compose up -d
npm run example
```

- navigate to http://localhost:3000/graphiql
- run an example query to prove successful stitching:

```gql
"""
`username` is accessible from the local schema
`verified` is accessible from the postgraphile schema
"""
query {
  localUser(id: 1) {
    username
    verified
  }
  user(id: 1) {
    username
    verified
  }
}
```